### PR TITLE
Add Marvel snap layout, tokens, zoom, and action strip

### DIFF
--- a/src/app.lua
+++ b/src/app.lua
@@ -24,14 +24,19 @@ local function buildSampleCards(gameId, defs)
     local c3 = CardModel.newInstance(state, defs[3])
 
     if gameId == "lotr" then
-        LayoutZones.placeCardsInZone(state.zones, "stagingArea", { c2 })
-        LayoutZones.placeCardsInZone(state.zones, "activeLocation", { c3 })
-        LayoutZones.placeCardsInZone(state.zones, "playerBoard", { c1 })
-        state.cards = { c2, c3, c1 }
+        LayoutZones.moveCard(state, c2, "stagingArea")
+        LayoutZones.moveCard(state, c3, "activeLocation")
+        LayoutZones.moveCard(state, c1, "playerBoard")
     else
-        LayoutZones.placeCardsInZone(state.zones, "encounterBoard", { c2 })
-        LayoutZones.placeCardsInZone(state.zones, "playerBoard", { c1, c3 })
-        state.cards = { c2, c1, c3 }
+        if gameId == "marvel" then
+            LayoutZones.moveCard(state, c2, "villain")
+            LayoutZones.moveCard(state, c3, "encounterBoard")
+            LayoutZones.moveCard(state, c1, "playerIdentity")
+        else
+            LayoutZones.moveCard(state, c2, "encounterBoard")
+            LayoutZones.moveCard(state, c1, "playerBoard")
+            LayoutZones.moveCard(state, c3, "playerBoard")
+        end
     end
 end
 
@@ -47,12 +52,17 @@ end
 local function loadGame(gameId)
     state.currentGameId = gameId
     state.selectedCard = nil
-    state.cards = {}
+    state.zoomCard = nil
     state.nextInstanceId = 1
     state.phaseIndex = 1
 
+    state.zones, state.zoneOrder = LayoutZones.createZonesForGame(gameId)
+    LayoutZones.initZoneCards(state)
     UIPiles.resetPiles(state)
-    state.zones = LayoutZones.createZonesForGame(gameId)
+
+    state.playerHand = state.zoneCards.playerHand or {}
+    state.playerDeck = state.zoneCards.playerDeck or {}
+    state.playerDiscard = state.zoneCards.playerDiscard or {}
 
     local defs = ContentSamples.sampleDefs(gameId)
     if #defs >= 3 then
@@ -60,7 +70,7 @@ local function loadGame(gameId)
     end
 
     fillDemoDeck(gameId)
-    LayoutZones.layoutHand(state)
+    LayoutZones.layoutAll(state)
 end
 
 local function loadInitialState()

--- a/src/layout_zones.lua
+++ b/src/layout_zones.lua
@@ -2,50 +2,129 @@ local love = require "love"
 
 local LayoutZones = {}
 
-function LayoutZones.createZonesForGame(gameId)
-    if gameId == "marvel" then
-        return {
-            encounterBoard = { id="encounterBoard", name="Villain / Schemes", x=60, y=140,  w=960, h=520 },
-            playerBoard    = { id="playerBoard",    name="Hero / Allies",     x=60, y=720,  w=960, h=540 },
-            playerHand     = { id="playerHand",     name="Hand",              x=60, y=1320, w=960, h=540 },
-        }
-    elseif gameId == "lotr" then
-        local topY, topH = 140, 520
-        return {
-            activeLocation = { id="activeLocation", name="Active Location", x=60, y=topY, w=300, h=topH },
-            stagingArea    = { id="stagingArea",    name="Staging / Quest", x=380, y=topY, w=640, h=topH },
-            playerBoard    = { id="playerBoard",    name="Heroes / Allies", x=60,  y=720, w=960, h=540 },
-            playerHand     = { id="playerHand",     name="Hand",            x=60,  y=1320,w=960, h=540 },
-        }
-    elseif gameId == "arkham" then
-        return {
-            encounterBoard = { id="encounterBoard", name="Agenda / Act",      x=60, y=140,  w=960, h=420 },
-            playerBoard    = { id="playerBoard",    name="Play Area",         x=60, y=600,  w=960, h=660 },
-            playerHand     = { id="playerHand",     name="Hand",              x=60, y=1320, w=960, h=540 },
-        }
-    elseif gameId == "ashes" then
-        return {
-            encounterBoard = { id="encounterBoard", name="Boss / Encounter",  x=60, y=140,  w=960, h=520 },
-            playerBoard    = { id="playerBoard",    name="Spellboard / Units",x=60, y=720,  w=960, h=540 },
-            playerHand     = { id="playerHand",     name="Hand",              x=60, y=1320, w=960, h=540 },
-        }
-    end
+local function buildDeckDiscardForHand(zone)
+    local padding = 16
+    local x = zone.x + padding
+    local y = zone.y + padding + 40
+    local pileW = 120
+    local pileH = 160
 
-    return {}
+    local deckRect = { x=x, y=y, w=pileW, h=pileH, id="playerDeck", name="Deck", layout="pile" }
+    local discardRect = { x=x, y=y + pileH + 24, w=pileW, h=pileH, id="playerDiscard", name="Discard", layout="pile" }
+    return deckRect, discardRect
 end
 
-function LayoutZones.placeCardsInZone(zones, zoneId, cardList)
-    local zone = zones[zoneId]
-    if not zone then return end
-    if #cardList == 0 then return end
+function LayoutZones.createZonesForGame(gameId)
+    local order, zones = {}, {}
 
+    if gameId == "marvel" then
+        local base = {
+            { id="villain",         name="Villain",                 x=60,  y=80,  w=260, h=400, layout="anchor" },
+            { id="mainScheme",      name="Main Scheme",             x=340, y=80,  w=260, h=400, layout="anchor" },
+            { id="encounterDeck",   name="Encounter Deck",          x=620, y=80,  w=150, h=200, layout="pile" },
+            { id="encounterDiscard",name="Encounter Discard",       x=620, y=300, w=150, h=200, layout="pile" },
+            { id="encounterBoard",  name="Encounter Board",         x=60,  y=500, w=710, h=220, layout="row" },
+            { id="playerIdentity",  name="Identity",                x=60,  y=750, w=260, h=420, layout="anchor", lock=true },
+            { id="playerPlay",      name="Upgrades / Supports",     x=340, y=750, w=720, h=420, layout="row" },
+            { id="playerHand",      name="Hand",                    x=60,  y=1320,w=960, h=540, layout="hand" },
+        }
+
+        for _, z in ipairs(base) do
+            zones[z.id] = z
+            table.insert(order, z)
+        end
+
+        local deckRect, discardRect = buildDeckDiscardForHand(zones.playerHand)
+        zones[deckRect.id] = deckRect
+        zones[discardRect.id] = discardRect
+        table.insert(order, deckRect)
+        table.insert(order, discardRect)
+    elseif gameId == "lotr" then
+        local topY, topH = 140, 520
+        local base = {
+            { id="activeLocation", name="Active Location", x=60, y=topY, w=300, h=topH, layout="anchor" },
+            { id="stagingArea",    name="Staging / Quest", x=380, y=topY, w=640, h=topH, layout="row" },
+            { id="playerBoard",    name="Heroes / Allies", x=60,  y=720, w=960, h=540, layout="row" },
+            { id="playerHand",     name="Hand",            x=60,  y=1320,w=960, h=540, layout="hand" },
+        }
+        for _, z in ipairs(base) do
+            zones[z.id] = z
+            table.insert(order, z)
+        end
+        local deckRect, discardRect = buildDeckDiscardForHand(zones.playerHand)
+        zones[deckRect.id] = deckRect
+        zones[discardRect.id] = discardRect
+        table.insert(order, deckRect)
+        table.insert(order, discardRect)
+    elseif gameId == "arkham" then
+        local base = {
+            { id="encounterBoard", name="Agenda / Act",      x=60, y=140,  w=960, h=420, layout="row" },
+            { id="playerBoard",    name="Play Area",         x=60, y=600,  w=960, h=660, layout="row" },
+            { id="playerHand",     name="Hand",              x=60, y=1320, w=960, h=540, layout="hand" },
+        }
+        for _, z in ipairs(base) do
+            zones[z.id] = z
+            table.insert(order, z)
+        end
+        local deckRect, discardRect = buildDeckDiscardForHand(zones.playerHand)
+        zones[deckRect.id] = deckRect
+        zones[discardRect.id] = discardRect
+        table.insert(order, deckRect)
+        table.insert(order, discardRect)
+    elseif gameId == "ashes" then
+        local base = {
+            { id="encounterBoard", name="Boss / Encounter",  x=60, y=140,  w=960, h=520, layout="row" },
+            { id="playerBoard",    name="Spellboard / Units",x=60, y=720,  w=960, h=540, layout="row" },
+            { id="playerHand",     name="Hand",              x=60, y=1320, w=960, h=540, layout="hand" },
+        }
+        for _, z in ipairs(base) do
+            zones[z.id] = z
+            table.insert(order, z)
+        end
+        local deckRect, discardRect = buildDeckDiscardForHand(zones.playerHand)
+        zones[deckRect.id] = deckRect
+        zones[discardRect.id] = discardRect
+        table.insert(order, deckRect)
+        table.insert(order, discardRect)
+    end
+
+    return zones, order
+end
+
+function LayoutZones.initZoneCards(state)
+    state.zoneCards = {}
+    for id, _ in pairs(state.zones) do
+        state.zoneCards[id] = {}
+    end
+end
+
+local function layoutPile(zone, cards)
+    if not zone or not cards then return end
+    local offset = 2
+    for i, card in ipairs(cards) do
+        card.x = zone.x + offset * (i - 1)
+        card.y = zone.y + offset * (i - 1)
+    end
+end
+
+local function layoutAnchor(zone, cards)
+    if not zone or not cards then return end
+    local cx = zone.x + zone.w / 2
+    local cy = zone.y + zone.h / 2
+    for _, card in ipairs(cards) do
+        card.x = cx - card.w / 2
+        card.y = cy - card.h / 2
+    end
+end
+
+local function layoutRow(zone, cards)
+    if not zone or not cards or #cards == 0 then return end
     local padding = 18
     local startX  = zone.x + padding
-    local y       = zone.y + (zone.h - cardList[1].h) / 2
+    local y       = zone.y + (zone.h - cards[1].h) / 2
 
-    local slotW = cardList[1].w + padding
-    for i, card in ipairs(cardList) do
-        card.zoneId = zoneId
+    local slotW = cards[1].w + padding
+    for i, card in ipairs(cards) do
         card.x = startX + (i-1) * slotW
         card.y = y
     end
@@ -53,8 +132,9 @@ end
 
 function LayoutZones.layoutHand(state)
     local zone = state.zones.playerHand
-    if not zone then return end
-    if #state.playerHand == 0 then return end
+    local hand = state.playerHand
+    if not zone or not hand then return end
+    if #hand == 0 then return end
 
     local padding = 16
     local pileW = 130
@@ -62,20 +142,103 @@ function LayoutZones.layoutHand(state)
     local right = zone.x + zone.w - padding
     local usableW = right - left
 
-    local cardW = state.playerHand[1].w
+    local cardW = hand[1].w
     local gap = 16
-    local totalW = #state.playerHand * cardW + (#state.playerHand - 1) * gap
+    local totalW = #hand * cardW + (#hand - 1) * gap
 
     local minScroll = math.min(0, usableW - totalW)
     if state.handScrollX < minScroll then state.handScrollX = minScroll end
     if state.handScrollX > 0 then state.handScrollX = 0 end
 
-    local y = zone.y + (zone.h - state.playerHand[1].h) / 2
-    for i, card in ipairs(state.playerHand) do
+    local y = zone.y + (zone.h - hand[1].h) / 2
+    for i, card in ipairs(hand) do
         card.zoneId = "playerHand"
         card.x = left + state.handScrollX + (i-1) * (cardW + gap)
         card.y = y
     end
+end
+
+function LayoutZones.layoutZone(state, zoneId)
+    local zone = state.zones[zoneId]
+    local cards = state.zoneCards[zoneId]
+    if not zone or not cards then return end
+
+    if zone.layout == "hand" then
+        LayoutZones.layoutHand(state)
+        return
+    elseif zone.layout == "pile" then
+        layoutPile(zone, cards)
+    elseif zone.layout == "anchor" then
+        layoutAnchor(zone, cards)
+    else
+        layoutRow(zone, cards)
+    end
+end
+
+function LayoutZones.layoutAll(state)
+    for id, _ in pairs(state.zoneCards) do
+        LayoutZones.layoutZone(state, id)
+    end
+end
+
+function LayoutZones.zoneAtPoint(state, x, y)
+    if not state.zoneOrder then return nil end
+    for i = #state.zoneOrder, 1, -1 do
+        local z = state.zoneOrder[i]
+        if x >= z.x and x <= z.x + z.w and y >= z.y and y <= z.y + z.h then
+            return z.id
+        end
+    end
+    return nil
+end
+
+local function removeFromZone(zoneCards, zoneId, card)
+    local list = zoneCards[zoneId]
+    if not list then return end
+    for i = #list, 1, -1 do
+        if list[i] == card then
+            table.remove(list, i)
+            return
+        end
+    end
+end
+
+function LayoutZones.moveCard(state, card, toZoneId)
+    if not card or not toZoneId then return end
+    local currentZone = card.zoneId and state.zones[card.zoneId]
+    if currentZone and currentZone.lock and toZoneId ~= card.zoneId then
+        LayoutZones.layoutZone(state, card.zoneId)
+        return
+    end
+
+    if not state.zones[toZoneId] then
+        LayoutZones.layoutZone(state, card.zoneId)
+        return
+    end
+
+    if card.zoneId == toZoneId then
+        LayoutZones.layoutZone(state, toZoneId)
+        return
+    end
+
+    local fromZone = card.zoneId
+    removeFromZone(state.zoneCards, fromZone, card)
+
+    if not state.zoneCards[toZoneId] then
+        state.zoneCards[toZoneId] = {}
+    end
+    table.insert(state.zoneCards[toZoneId], card)
+    card.zoneId = toZoneId
+
+    if fromZone then LayoutZones.layoutZone(state, fromZone) end
+    LayoutZones.layoutZone(state, toZoneId)
+end
+
+function LayoutZones.ensureZone(state, zoneId)
+    if not state.zoneCards[zoneId] then
+        state.zoneCards[zoneId] = {}
+    end
+    return state.zoneCards[zoneId]
 end
 
 return LayoutZones

--- a/src/model_card.lua
+++ b/src/model_card.lua
@@ -27,7 +27,7 @@ function CardModel.newInstance(state, def, sideId)
         dragOffsetY  = 0,
 
         exhausted    = false,
-        tokens       = {},
+        tokens       = { damage=0, threat=0, counters=0, stunned=false, confused=false, tough=false },
         faceUp       = true,
     }
 
@@ -57,6 +57,43 @@ end
 function CardModel.toggleExhaust(card)
     if not card then return end
     card.exhausted = not card.exhausted
+end
+
+local function clampToken(card, key)
+    if card.tokens[key] and card.tokens[key] < 0 then
+        card.tokens[key] = 0
+    end
+end
+
+function CardModel.adjustToken(card, key, delta)
+    if not card or not key or not delta then return end
+    CardModel.ensureTokens(card)
+    local current = card.tokens[key] or 0
+    if type(current) == "boolean" then
+        card.tokens[key] = delta > 0
+        return
+    end
+    card.tokens[key] = current + delta
+    clampToken(card, key)
+end
+
+function CardModel.toggleStatus(card, key)
+    if not card or not key then return end
+    CardModel.ensureTokens(card)
+    local current = card.tokens[key]
+    if type(current) == "boolean" then
+        card.tokens[key] = not current
+    end
+end
+
+function CardModel.ensureTokens(card)
+    card.tokens = card.tokens or {}
+    card.tokens.damage = card.tokens.damage or 0
+    card.tokens.threat = card.tokens.threat or 0
+    card.tokens.counters = card.tokens.counters or 0
+    card.tokens.stunned = card.tokens.stunned or false
+    card.tokens.confused = card.tokens.confused or false
+    card.tokens.tough = card.tokens.tough or false
 end
 
 return CardModel

--- a/src/state.lua
+++ b/src/state.lua
@@ -14,6 +14,8 @@ local function newState()
         offsetY = 0,
 
         zones = {},
+        zoneOrder = {},
+        zoneCards = {},
         cards = {},
         selectedCard = nil,
 
@@ -21,6 +23,10 @@ local function newState()
         phaseButtons = {},
         drawBtnRect = nil,
         discardBtnRect = nil,
+        actionButtons = {},
+        zoomCard = nil,
+        lastClickTime = nil,
+        lastClickCard = nil,
 
         currentGameId = "marvel",
         phaseIndex = 1,

--- a/src/ui_actionstrip.lua
+++ b/src/ui_actionstrip.lua
@@ -1,0 +1,124 @@
+local love = require "love"
+
+local LayoutZones = require "src.layout_zones"
+local CardModel = require "src.model_card"
+
+local ActionStrip = {}
+
+local function addButton(buttons, id, label, enabled)
+    table.insert(buttons, { id=id, label=label, enabled=enabled ~= false })
+end
+
+local function hasFlip(card)
+    if not card then return false end
+    local side = CardModel.getActiveSide(card)
+    if side and side.canFlipTo and #side.canFlipTo > 0 then return true end
+    local count = 0
+    for _ in pairs(card.def.sides or {}) do count = count + 1 end
+    return count > 1
+end
+
+function ActionStrip.buildButtons(state)
+    local buttons = {}
+    local card = state.selectedCard
+    if not card then return buttons end
+
+    addButton(buttons, "zoom", "Zoom", true)
+    addButton(buttons, "flip", "Flip / Advance", hasFlip(card))
+    addButton(buttons, "exhaust", card.exhausted and "Ready" or "Exhaust", true)
+    addButton(buttons, "dmg_plus", "+Damage", true)
+    addButton(buttons, "dmg_minus", "-Damage", true)
+    addButton(buttons, "thr_plus", "+Threat", true)
+    addButton(buttons, "thr_minus", "-Threat", true)
+    addButton(buttons, "stunned", card.tokens.stunned and "Clear Stun" or "Stun", true)
+    addButton(buttons, "confused", card.tokens.confused and "Clear Confuse" or "Confuse", true)
+    addButton(buttons, "tough", card.tokens.tough and "Clear Tough" or "Tough", true)
+
+    local hasHand = state.zones.playerHand ~= nil
+    local hasDiscard = state.zones.playerDiscard ~= nil
+    local hasPlay = state.zones.playerPlay ~= nil
+    local hasEncounter = state.zones.encounterBoard ~= nil
+
+    addButton(buttons, "move_hand", "To Hand", hasHand and card.zoneId ~= "playerHand")
+    addButton(buttons, "move_discard", "To Discard", hasDiscard and card.zoneId ~= "playerDiscard")
+    addButton(buttons, "move_play", "To Play", hasPlay and card.zoneId ~= "playerPlay")
+    addButton(buttons, "move_encounter", "To Encounter", hasEncounter and card.zoneId ~= "encounterBoard")
+
+    return buttons
+end
+
+function ActionStrip.handleClick(state, id)
+    local card = state.selectedCard
+    if not card then return end
+
+    if id == "zoom" then
+        state.zoomCard = card
+        return
+    elseif id == "flip" then
+        CardModel.flip(card)
+    elseif id == "exhaust" then
+        CardModel.toggleExhaust(card)
+    elseif id == "dmg_plus" then
+        CardModel.adjustToken(card, "damage", 1)
+    elseif id == "dmg_minus" then
+        CardModel.adjustToken(card, "damage", -1)
+    elseif id == "thr_plus" then
+        CardModel.adjustToken(card, "threat", 1)
+    elseif id == "thr_minus" then
+        CardModel.adjustToken(card, "threat", -1)
+    elseif id == "stunned" then
+        CardModel.toggleStatus(card, "stunned")
+    elseif id == "confused" then
+        CardModel.toggleStatus(card, "confused")
+    elseif id == "tough" then
+        CardModel.toggleStatus(card, "tough")
+    elseif id == "move_hand" then
+        LayoutZones.moveCard(state, card, "playerHand")
+    elseif id == "move_discard" then
+        LayoutZones.moveCard(state, card, "playerDiscard")
+    elseif id == "move_play" then
+        LayoutZones.moveCard(state, card, "playerPlay")
+    elseif id == "move_encounter" then
+        LayoutZones.moveCard(state, card, "encounterBoard")
+    end
+end
+
+function ActionStrip.draw(state)
+    local buttons = ActionStrip.buildButtons(state)
+    state.actionButtons = {}
+    if #buttons == 0 then return end
+
+    local stripX = 60
+    local stripY = 1180
+    local stripW = state.VIRTUAL_WIDTH - 120
+    local stripH = 90
+
+    love.graphics.setColor(0.12, 0.12, 0.18, 0.9)
+    love.graphics.rectangle("fill", stripX, stripY, stripW, stripH, 16, 16)
+    love.graphics.setColor(0.5, 0.5, 0.7)
+    love.graphics.rectangle("line", stripX, stripY, stripW, stripH, 16, 16)
+
+    local gap = 10
+    local btnW = math.min(170, math.floor((stripW - gap * (#buttons + 1)) / #buttons))
+    local btnH = stripH - 20
+    local x = stripX + gap
+    local y = stripY + 10
+
+    for _, btn in ipairs(buttons) do
+        local rect = { x=x, y=y, w=btnW, h=btnH, id=btn.id, enabled=btn.enabled ~= false }
+        table.insert(state.actionButtons, rect)
+
+        local enabled = btn.enabled
+        love.graphics.setColor(enabled and 0.2 or 0.12, enabled and 0.25 or 0.12, enabled and 0.34 or 0.18)
+        love.graphics.rectangle("fill", rect.x, rect.y, rect.w, rect.h, 10, 10)
+        love.graphics.setColor(enabled and 0.9 or 0.6, enabled and 0.9 or 0.6, enabled and 0.95 or 0.65)
+        love.graphics.rectangle("line", rect.x, rect.y, rect.w, rect.h, 10, 10)
+        love.graphics.setColor(1, 1, 1, enabled and 1 or 0.6)
+        love.graphics.setFont(state.fonts.small)
+        love.graphics.printf(btn.label, rect.x + 6, rect.y + 16, rect.w - 12, "center")
+
+        x = x + btnW + gap
+    end
+end
+
+return ActionStrip


### PR DESCRIPTION
Add Marvel-focused zones (villain, main scheme, encounter deck/discard, identity, play, hand) and snap-on-drop via centralized moveCard/zone layouts.

Treat piles as real zones; keep hand/deck/discard in sync with zone storage and lock identity anchors.

Add token model + badges (damage, threat, counters, stunned/confused/tough) with keyboard and action-strip controls.

Introduce zoom modal (double-click or Z) and bottom action strip (Flip, Exhaust/Ready, Move to 

Hand/Discard/Play/Encounter, +/- Damage/Threat, status toggles).

Testing:

Manually tested to verify functionality.